### PR TITLE
Add a feature to round building floats

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -46,10 +46,10 @@ pub struct EditArgs {
     /// Replace icon text.
     #[clap(short = 't', long)]
     pub icon_text: Option<String>,
-    /// Round location and rotation of all buildings to 1/64th of a tile and 1 degree.
+    /// Snap location and rotation of almsot aligned buildings to half a tile and 90 degrees.
     ///
-    /// This decreases blueprint size by about 30% and makes almost-on-grid buildings perfectly
-    /// on-grid. Resulting blueprints should still work. No guarantees.
+    /// This decreases blueprint size by about 20% and makes almost-aligned buildings perfectly
+    /// aligned. Resulting blueprints should still work. No guarantees.
     #[clap(long, default_value_t = false)]
     pub round: bool,
 }

--- a/src/args.rs
+++ b/src/args.rs
@@ -46,6 +46,12 @@ pub struct EditArgs {
     /// Replace icon text.
     #[clap(short = 't', long)]
     pub icon_text: Option<String>,
+    /// Round location and rotation of all buildings to 1/64th of a tile and 1 degree.
+    ///
+    /// This decreases blueprint size by about 30% and makes almost-on-grid buildings perfectly
+    /// on-grid. Resulting blueprints should still work. No guarantees.
+    #[clap(long, default_value_t = false)]
+    pub round: bool,
 }
 
 #[derive(Subcommand, Debug)]

--- a/src/blueprint.rs
+++ b/src/blueprint.rs
@@ -5,8 +5,8 @@ use std::str::FromStr;
 use crate::data::blueprint::BlueprintData;
 use crate::data::visit::{Visit, Visitor};
 use crate::error::{some_error, Error};
-use base64::Engine;
 use base64::engine::GeneralPurpose;
+use base64::Engine;
 use binrw::{BinReaderExt, BinWrite};
 use flate2::read::GzDecoder;
 use flate2::write::GzEncoder;
@@ -35,8 +35,9 @@ impl Blueprint {
     }
 
     fn unpack_data(b64data: &str) -> anyhow::Result<(BlueprintData, Vec<u8>)> {
-        let zipped_data =
-            B64.decode(b64data).map_err(|_| some_error("Failed to base64 decode blueprint"))?;
+        let zipped_data = B64
+            .decode(b64data)
+            .map_err(|_| some_error("Failed to base64 decode blueprint"))?;
         let mut d = GzDecoder::new(zipped_data.as_slice());
         let mut data = vec![];
         d.read_to_end(&mut data)?;

--- a/src/edit/mod.rs
+++ b/src/edit/mod.rs
@@ -13,10 +13,12 @@ use crate::{
 
 use self::{
     replace::{Replace, ReplaceBuilding, ReplaceItem, ReplaceRecipe},
+    round::Round,
     stats::GetStats,
 };
 
 pub(crate) mod replace;
+pub(crate) mod round;
 pub(crate) mod stats;
 
 fn map_using_map<T: DSPEnum + 'static>(m: HashMap<T, T>) -> Box<Replace<T>> {
@@ -87,5 +89,10 @@ impl EditBlueprint {
         let mut r = ReplaceBuilding::new(&m);
         r.visit_blueprint(&mut self.0);
         Ok(())
+    }
+
+    pub fn round_floats(&mut self) {
+        let mut r = Round;
+        r.visit_blueprint(&mut self.0);
     }
 }

--- a/src/edit/round.rs
+++ b/src/edit/round.rs
@@ -6,14 +6,20 @@ use crate::data::{
 pub struct Round;
 
 impl Round {
-    // Round yaw to multiple of a degree.
+    // Round yaw to a right angle if we're off by less than 3 degrees.
     fn round_yaw(&self, yaw: &mut f32) {
-        *yaw = (*yaw).round()
+        let rounded: f32 = ((*yaw as f64 / 90.0).round() * 90.0) as f32;
+        if (rounded - *yaw).abs() <= 3.0 {
+            *yaw = rounded;
+        }
     }
 
-    // Round loc to 1/64th of a tile.
+    // Round loc to closest half a tile if we're off by less than 1/64th.
     fn round_loc(&self, loc: &mut f32) {
-        *loc = (((*loc as f64) * 64.0).round() / 64.0) as f32
+        let rounded: f32 = (*loc * 2.0).round() / 2.0;
+        if (rounded - *loc).abs() <= 1.0 / 64.0 {
+            *loc = rounded;
+        }
     }
 }
 

--- a/src/edit/round.rs
+++ b/src/edit/round.rs
@@ -1,0 +1,33 @@
+use crate::data::{
+    building::Building,
+    visit::{Visit, Visitor},
+};
+
+pub struct Round;
+
+impl Round {
+    // Round yaw to multiple of a degree.
+    fn round_yaw(&self, yaw: &mut f32) {
+        *yaw = (*yaw).round()
+    }
+
+    // Round loc to 1/64th of a tile.
+    fn round_loc(&self, loc: &mut f32) {
+        *loc = (((*loc as f64) * 64.0).round() / 64.0) as f32
+    }
+}
+
+impl Visitor for Round {
+    fn visit_building(&mut self, v: &mut Building) {
+        let h = &mut v.header;
+        self.round_loc(&mut h.local_offset_x);
+        self.round_loc(&mut h.local_offset_y);
+        self.round_loc(&mut h.local_offset_z);
+        self.round_loc(&mut h.local_offset_x2);
+        self.round_loc(&mut h.local_offset_y2);
+        self.round_loc(&mut h.local_offset_z2);
+        self.round_yaw(&mut h.yaw);
+        self.round_yaw(&mut h.yaw2);
+        v.visit(self)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -210,6 +210,11 @@ pub fn cmdline() -> anyhow::Result<()> {
             if let Some(i) = eargs.icon_text {
                 bp.set_icon_text(&i);
             }
+
+            if eargs.round {
+                bp.round_floats();
+            }
+
             output.write_all(bp.0.into_bp_string(args.compression_level)?.as_bytes())?;
             output.flush_if_stdout()?;
         }


### PR DESCRIPTION
The new flag will round locations and rotations of buildings to 1/64th of a tile and 1 degree respectively. It decreases blueprint size by 30% or so. Also, the game tends to put "on-grid" buildings an epsilon off-grid, so this helps perfectly align them.

We explicitly give no guarantees for the changed blueprints to work.

Kudos to @Neutron3529 for suggesting and initially implementing this feature.