### PR TITLE
enable -9 by default

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -14,6 +14,10 @@ pub struct Args {
     /// Output file. If absent or '-', writes to standard output.
     #[clap(short, long)]
     pub output: Option<String>,
+    /// Compression level. Uses 6 by default, like DSP does. Set it to 9 for about 5% smaller
+    /// blueprints that (almost certainly) still work fine.
+    #[clap(short, long, default_value_t = 6)]
+    pub compression_level: u32
 }
 
 #[derive(Parser, Debug)]

--- a/src/blueprint.rs
+++ b/src/blueprint.rs
@@ -65,8 +65,8 @@ impl Blueprint {
         MD5::new(Algo::MD5F).process(data.as_bytes())
     }
 
-    fn pack_data(&self) -> anyhow::Result<String> {
-        let mut e = GzEncoder::new(Vec::new(), Compression::default());
+    fn pack_data(&self, level: Compression) -> anyhow::Result<String> {
+        let mut e = GzEncoder::new(Vec::new(), level);
         let mut ws = Cursor::new(vec![]);
         self.data.write_le(&mut ws)?;
         e.write_all(&ws.into_inner()).unwrap();
@@ -152,8 +152,7 @@ impl Blueprint {
             raw_bp,
         ))
     }
-
-    pub fn into_bp_string(&self) -> anyhow::Result<String> {
+    pub fn into_bp_string(&self, level: u32) -> anyhow::Result<String> {
         let icons = self.icons.map(|x| x.to_string()).join(",");
         let mut out = format!(
             "BLUEPRINT:0,{},{},0,{},{},{},{}\"{}",
@@ -163,7 +162,7 @@ impl Blueprint {
             self.game_version,
             self.icon_text,
             self.desc,
-            self.pack_data()?
+            self.pack_data(Compression::new(level))?
         );
         let hash = Self::hash(&out);
         write!(&mut out, "\"").unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,7 +157,7 @@ pub fn cmdline() -> anyhow::Result<()> {
             input.read_to_end(&mut data)?;
             let data = String::from_utf8(data)?;
             let bp = Blueprint::new_from_json(&data)?;
-            output.write_all(bp.into_bp_string()?.as_bytes())?;
+            output.write_all(bp.into_bp_string(args.compression_level)?.as_bytes())?;
             output.flush_if_stdout()?;
         }
         Commands::Edit(eargs) => {
@@ -210,7 +210,7 @@ pub fn cmdline() -> anyhow::Result<()> {
             if let Some(i) = eargs.icon_text {
                 bp.set_icon_text(&i);
             }
-            output.write_all(bp.0.into_bp_string()?.as_bytes())?;
+            output.write_all(bp.0.into_bp_string(args.compression_level)?.as_bytes())?;
             output.flush_if_stdout()?;
         }
         Commands::Info => {

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -65,8 +65,9 @@ fn load(buf: &PyAny) -> PyResult<PyBlueprint> {
 }
 
 #[pyfunction]
-fn save<'a>(py: Python<'a>, bp: &PyBlueprint) -> PyResult<&'a PyBytes> {
-    let data = bp.0 .0.into_bp_string().map_err(ve)?;
+fn save<'a>(py: Python<'a>, bp: &PyBlueprint, compression_level: Option<u32>) -> PyResult<&'a PyBytes> {
+    let cl = compression_level.unwrap_or(6);
+    let data = bp.0 .0.into_bp_string(cl).map_err(ve)?;
     Ok(PyBytes::new(py, data.as_bytes()))
 }
 


### PR DESCRIPTION
Currently the gz level is 6, which yields a ~5% bigger file than using level 9.

Thus I provide an option to tweak the blueprint's gz level.

Since the compression level only affect the compression time but not the decompression time

We might got a smaller blueprint if enable the level to 9 by default.

This change, does not like the rounding change, is a totally free change.